### PR TITLE
[BUG] Fix issue #44 - overflow with bad settings file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ yarn_mappings=1.19.2+build.1
 loader_version=0.14.9
 
 # Mod Properties
-mod_version=1.3.1-1
+mod_version=1.3.1-2
 maven_group=com.peasenet
 archives_base_name=gavinsmod
 

--- a/src/main/java/com/peasenet/main/GavinsMod.java
+++ b/src/main/java/com/peasenet/main/GavinsMod.java
@@ -50,7 +50,7 @@ public class GavinsMod implements ModInitializer {
     /**
      * The current version of the mod.
      */
-    public static final String VERSION = "v1.3";
+    public static final String VERSION = "v1.3.1-2";
 
     /**
      * The gui used to display the main mod menu.

--- a/src/main/java/com/peasenet/main/Settings.java
+++ b/src/main/java/com/peasenet/main/Settings.java
@@ -173,7 +173,6 @@ public class Settings {
         } catch (Exception e) {
             GavinsMod.LOGGER.error("Error reading settings from file. Saving defaults.");
             loadDefault();
-            save();
         }
     }
 
@@ -224,21 +223,13 @@ public class Settings {
         // rename settings file to settings.bak
         var bakFile = cfgFile + ".bak";
         int bakCount = 1;
-        // check if the backup file exists
-        if (!Files.exists(Paths.get(bakFile))) {
-            loadDefault();
-            save();
-            return;
+        // if bak file exists, rename it to settings.bak.1, settings.bak.2, etc.
+        while(new File(bakFile).exists()) {
+            bakFile = cfgFile + ".bak." + bakCount;
+            bakCount++;
         }
-        while (Files.exists(Paths.get(bakFile))) {
-            bakFile = cfgFile + ".bak" + bakCount;
-        }
-        try {
-            Files.move(Paths.get(cfgFile), Paths.get(bakFile));
-        } catch (IOException e1) {
-            GavinsMod.LOGGER.error("Error renaming settings file.");
-            GavinsMod.LOGGER.error(e1.getMessage());
-        }
+        // move the settings file to the bak file
+        new File(cfgFile).renameTo(new File(bakFile));
         loadDefaultXrayBlocks();
         settings.putAll(default_settings);
         save();


### PR DESCRIPTION
Describe your changes
--

Fix a stack overflow pertaining to initializing/loading default settings -  fixes #44 

Have you tested your change?
--

- [x] Yes
- [ ] No

This fix properly initializes the settings file, and re-creates the settings file (while making a copy).
Tested a "corrupt" settings file with the following data:
```json
{
  "xray.blocks": [
    "Block{minecraft:gold_ore}",
    "Block{minecraft:deepslate_gold_ore}",
    "Block{minecraft:iron_ore}",
    "Block{minecraft:deepslate_iron_ore}",
    "Block{minecraft:deepslate_coal_ore}",
    "Block{minecraft:nether_gold_ore}",
    "Block{minecraft:lapis_ore}",
    "Block{minecraft:deepslate_lapis_ore}",
    "Block{minecraft:diamond_ore}",
    "Block{minecraft:deepslate_diamond_ore}",
    "Block{minecraft:emerald_ore}",
    "Block{minecraft:deepslate_emerald_ore}",
    "Block{minecraft:nether_quartz_ore}",
    "Block{minecraft:sculk}",
    "Block{minecraft:copper_ore}",
    "Block{minecraft:deepslate_copper_ore}",
    "Block{Minecraft:banana}"
Corrupted
  ],
  "misc.fps.color.ok": {
    "red": 255,
    "green": 255,
    "blue": 0
  },
  "tracer.mob.peaceful.color": {
    "red": 0,
    "green": 255,
    "blue": 0
  },
  "tracer.player.color": {
    "red": 255,
    "green": 255,
    "blue": 0
  },
  "waypoint.locations": [
    {
      "x": -7,
      "y": 76,
      "z": 9,
      "name": "test",
      "color": {
        "red": 255,
        "green": 255,
        "blue": 255
      },
      "enabled": true,
      "tracerEnabled": true,
      "espEnabled": true
    }
  ],
  "misc.messages": true,
  "misc.fps.color.enabled": false,
  "esp.item.color": {
    "red": 0,
    "green": 255,
    "blue": 255
  },
  "tracer.mob.hostile.color": {
    "red": 255,
    "green": 0,
    "blue": 0
  },
  "tracer.item.color": {
    "red": 0,
    "green": 255,
    "blue": 255
  },
  "esp.mob.peaceful.color": {
    "red": 0,
    "green": 255,
    "blue": 0
  },
  "misc.fps.color.fast": {
    "red": 0,
    "green": 255,
    "blue": 0
  },
  "esp.player.color": {
    "red": 255,
    "green": 255,
    "blue": 0
  },
  "esp.chest.color": {
    "red": 255,
    "green": 0,
    "blue": 255
  },
  "render.fullbright.autofullbright": false,
  "render.fullbright.gammafade": true,
  "xray.disable_culling": true,
  "misc.fps.color.slow": {
    "red": 255,
    "green": 0,
    "blue": 0
  },
  "esp.mob.hostile.color": {
    "red": 255,
    "green": 0,
    "blue": 0
  },
  "tracer.chest.color": {
    "red": 255,
    "green": 0,
    "blue": 255
  }
}
broken
```
and the mod properly detects, recreates, and copies the "broken" settings file.

What is your motivation behind this change?
--

Bug fix/closes issue #44.